### PR TITLE
fix: Check negative patterns before trimming

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,13 @@ module.exports = function(glob, options) {
     rootDir = escape(rootDir);
   }
 
+  // store last character before glob is modified
+  var suffix = glob.slice(-1);
+
+  // check to see if glob is negated (and not a leading negated-extglob)
+  var ing = isNegated(glob);
+  glob = ing.pattern;
+
   // trim starting ./ from glob patterns
   if (glob.slice(0, 2) === './') {
     glob = glob.slice(2);
@@ -34,13 +41,6 @@ module.exports = function(glob, options) {
   if (glob.length === 1 && glob === '.') {
     glob = '';
   }
-
-  // store last character before glob is modified
-  var suffix = glob.slice(-1);
-
-  // check to see if glob is negated (and not a leading negated-extglob)
-  var ing = isNegated(glob);
-  glob = ing.pattern;
 
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "gulp-format-md": "^2.0.0",
-    "mocha": "^10.1.0"
+    "mocha": "^3.0.2"
   },
   "keywords": [
     "absolute",

--- a/test.js
+++ b/test.js
@@ -45,6 +45,21 @@ describe('resolve', function() {
       assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
     });
 
+    it('should make a negative glob (starting with `./`) absolute', function() {
+      actual = resolve('!./a/*.js');
+      assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
+    });
+
+    it('should make a negative glob (just `./`) absolute', function() {
+      actual = resolve('!./');
+      assert.equal(actual, '!' + unixify(path.resolve('.')) + '/');
+    });
+
+    it('should make a negative glob (just `.`) absolute', function() {
+      actual = resolve('!.');
+      assert.equal(actual, '!' + unixify(path.resolve('.')));
+    });
+
     it('should make a negative extglob absolute', function() {
       actual = resolve('!(foo)');
       assert.equal(actual, unixify(path.resolve('!(foo)')));


### PR DESCRIPTION
While trying to implement this in `glob-stream`, I encountered a problem where my negative patterns weren't matching. I traced it to the `./` not being removed in negative globs.

This moves the `isNegated` check above the trimming logic so the `!` will be removed from the pattern before trimming is attempted.