### PR TITLE
fix: Resolve ../ at the beginning of globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,5 +80,12 @@ function join(dir, glob) {
     glob = glob.slice(1);
   }
   if (!glob) return dir;
+
+  // Resolve `../` segements in the  glob
+  while (glob.slice(0, 3) === '../') {
+    dir = dir.slice(0, dir.lastIndexOf('/'));
+    glob = glob.slice(3);
+  }
+
   return dir + '/' + glob;
 }

--- a/test.js
+++ b/test.js
@@ -40,6 +40,18 @@ describe('resolve', function() {
       assert.equal(actual, unixify(path.resolve(fixture)) + '/');
     });
 
+    it('should handle ../ at the beginnnig of a glob', function() {
+      fixture = '../fixtures/whatsgoingon/*/';
+      actual = resolve(fixture, {cwd: __dirname});
+      assert.equal(actual, unixify(path.resolve(fixture)) + '/');
+    });
+
+    it('should handle multiple ../ at the beginnnig of a glob', function() {
+      fixture = '../../fixtures/whatsgoingon/*/';
+      actual = resolve(fixture, {cwd: __dirname});
+      assert.equal(actual, unixify(path.resolve(fixture)) + '/');
+    });
+
     it('should make a negative glob absolute', function() {
       actual = resolve('!a/*.js');
       assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
@@ -58,6 +70,16 @@ describe('resolve', function() {
     it('should make a negative glob (just `.`) absolute', function() {
       actual = resolve('!.');
       assert.equal(actual, '!' + unixify(path.resolve('.')));
+    });
+
+    it('should make a negative glob (starting with ../) absolute', function() {
+      actual = resolve('!../fixtures/whatsgoingon/*/');
+      assert.equal(actual, '!' + unixify(path.resolve('../fixtures/whatsgoingon/*/')) + '/');
+    });
+
+    it('should make a negative glob (starting with multiple ../) absolute', function() {
+      actual = resolve('!../../fixtures/whatsgoingon/*/');
+      assert.equal(actual, '!' + unixify(path.resolve('../../fixtures/whatsgoingon/*/')) + '/');
     });
 
     it('should make a negative extglob absolute', function() {


### PR DESCRIPTION
This ensures support for any number of `../` at the beginning of a glob.

Since I had just resolved the escape characters and the `./` issue, it was apparent to me as I was managing the gulp 5 backlog that these issues would also need to be resolved in `to-absolute-glob`: https://github.com/gulpjs/gulp/issues/2211, https://github.com/gulpjs/vinyl-fs/issues/312, and https://github.com/gulpjs/vinyl-fs/issues/306